### PR TITLE
Change default options.module to null if options.target is ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ See [Error handling](#error-handling) for details.
 
 #### options.module
 Type: `String` (`"commonjs"` or `"amd"`)
-Default: `"commonjs"`
+Default: `null` (if `options.target` is `"ES6"`), or `"commonjs"` (otherwise)
 
 `--module` option for `tsc` command.
 
 #### options.target
-Type: `String` (`"ES3"` or `"ES5"`)
+Type: `String` (`"ES3"`, `"ES5"`, or `"ES6"`)
 Default: `"ES3"`
 
 `--target` option for `tsc` command.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -20,10 +20,12 @@ function Compiler(sourceFiles, options) {
 
   this.sourceFiles = sourceFiles || [];
 
+  var defaultModule = options && options.target === 'ES6' ? null : 'commonjs';
+
   this.options = _.extend({
     tscPath:           null,
     tscSearch:         null,
-    module:            'commonjs',
+    module:            defaultModule,
     target:            'ES3',
     out:               null,
     outDir:            null,
@@ -181,7 +183,7 @@ Compiler.prototype.prepareTscArgumentsFile = function(callback) {
         var tscArguments = this.buildTscArguments(version);
         var content = '"' + tscArguments.join('"\n"') + '"';
         this.tscArgumentsFile = path.join(this.tempDestination, 'tscArguments');
-        fs.writeFile(this.tscArgumentsFile, content, callback); 
+        fs.writeFile(this.tscArgumentsFile, content, callback);
     }.bind(this));
 };
 


### PR DESCRIPTION
Setting `--module` to `"commonjs"` when `--target` is `"ES6"` will trigger
`"error TS1204: Cannot compile external modules into amd or commonjs when targeting es6 or higher."`
