### PR TITLE
Added emitDecoratorMetadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ By default, gulp-tsc ignores warnings from tsc command and emits compiled js fil
 
 If set this option to true, gulp-tsc never emits compiled files when tsc command returned warnings or errors.
 
+#### options.emitDecoratorMetadata
+Type: `Boolean`
+Default: `false`
+
+`--emitDecoratorMetadata` option for `tsc` command.
+
+Emit decorator metadata.
+
 ## Error handling
 
 If gulp-tsc fails to compile files, it emits `error` event with `gutil.PluginError` as the manner of gulp plugins.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -43,7 +43,8 @@ function Compiler(sourceFiles, options) {
     noLib:             false,
     keepTree:          true,
     pathFilter:        null,
-    safe:              false
+    safe:              false,
+    emitDecoratorMetadata: false,
   }, options);
   this.options.sourceMap = this.options.sourceMap || this.options.sourcemap;
   delete this.options.sourcemap;
@@ -78,6 +79,7 @@ Compiler.prototype.buildTscArguments = function (version) {
   if (this.options.removeComments)    args.push('--removeComments');
   if (this.options.sourceMap)         args.push('--sourcemap');
   if (this.options.noLib)             args.push('--noLib');
+  if (this.options.emitDecoratorMetadata)    args.push('--emitDecoratorMetadata');
 
   if (this.tempDestination) {
     args.push('--outDir', this.tempDestination);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tsc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Kota Saito <kotas.nico@gmail.com> (https://github.com/kotas)",
   "copyright": "2014 Kota Saito",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tsc",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "author": "Kota Saito <kotas.nico@gmail.com> (https://github.com/kotas)",
   "copyright": "2014 Kota Saito",
   "contributors": [

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -16,11 +16,8 @@ var abort  = function (err) { throw err; };
 var ignore = function (err) { };
 var currentVersion = 'INVALID';
 
-var isVersion150 = function (version) {
-    var result = version === '1.5.0-alpha' 
-        || version === '1.5.0-beta' 
-        || version === '1.5.0';
-    return result;
+var isVersionGte150 = function (version) {
+    return version.indexOf('1.5.') === 0;
 }
 
 gulp.task('default', ['version', 'all']);
@@ -94,7 +91,7 @@ gulp.task('test5', ['clean'], function () {
   return gulp.src('src-broken/error.ts')
     .pipe(typescript()).on('error', ignore)
     .pipe(gulp.dest('build/test5'))
-    .pipe(!isVersion150(currentVersion)
+    .pipe(!isVersionGte150(currentVersion)
           ? expect([]) : expect(['build/test5/error.js'])
          );
 });
@@ -204,7 +201,7 @@ gulp.task('test15', ['clean'], function () {
   return gulp.src('src-broken/error.ts')
     .pipe(typescript({ emitError: false }))
     .pipe(gulp.dest('build/test15'))
-    .pipe(!isVersion150(currentVersion)
+    .pipe(!isVersionGte150(currentVersion)
           ? expect([]) : expect(['build/test15/error.js'])
          );
 });
@@ -247,7 +244,7 @@ gulp.task('test17', ['clean'], function () {
     .pipe(gulp.dest('build/test17/s2'));
 
   return es.merge(one, two)
-    .pipe(!isVersion150(currentVersion)
+    .pipe(!isVersionGte150(currentVersion)
           ? expect(['build/test17/s2/b.js'])
           : expect(['build/test17/s1/error.js', 'build/test17/s2/b.js'])
          )


### PR DESCRIPTION
I was missing this option, necessary for instance to allow Angular2 projects to inject components. I have tested against a sample [Angular2 project](https://github.com/codependent/dopangular), working without any problem.
