### PR TITLE
Added support for experimentalDecorators flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,15 @@ Default: `false`
 
 Emit decorator metadata.
 
+
+#### options.experimentalDecorators
+Type: `Boolean`
+Default: `false`
+
+`--experimentalDecorators` option for `tsc` command.
+
+Enable experimental Decorator support.
+
 ## Error handling
 
 If gulp-tsc fails to compile files, it emits `error` event with `gutil.PluginError` as the manner of gulp plugins.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -43,6 +43,7 @@ function Compiler(sourceFiles, options) {
         pathFilter:        null,
         safe:              false,
         emitDecoratorMetadata: false,
+        experimentalDecorators: false
     }, options);
     this.options.sourceMap = this.options.sourceMap || this.options.sourcemap;
     delete this.options.sourcemap;
@@ -78,6 +79,7 @@ Compiler.prototype.buildTscArguments = function (version) {
   if (this.options.sourceMap)         args.push('--sourcemap');
   if (this.options.noLib)             args.push('--noLib');
   if (this.options.emitDecoratorMetadata)    args.push('--emitDecoratorMetadata');
+  if (this.options.experimentalDecorators)    args.push('--experimentalDecorators');
 
   if (this.tempDestination) {
     args.push('--outDir', this.tempDestination);


### PR DESCRIPTION
When currently writing Angular2 Applications the experimentalDecorators flag has to be passed to the typescript compiler, so this pull request adds support for the flag
