### PR TITLE
Support for future tsc parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,17 +300,17 @@ Default: `false`
 Enable experimental Decorator support.
 
 #### options.additionalTscParameters
-Type: String
-Default: null
+Type: Array of string
+Default: []
 
-This option is used to pass any parameter to tsc command. Especially it can be used to pass parameters not yet suported by gulp-tsc. 
+This option is used to pass any parameter to tsc command. Especially it can be used to pass parameters not yet suported by gulp-tsc. You have to pass each parameter separately.
 
 Example:
 ```
 gulp.task('compile', function(){
   gulp.src(['src/**/*.tsx'])
     .pipe(typescript({
-      additionalTscParameters: '--jsx react'
+      additionalTscParameters: ['--jsx', 'react']
     }))
     .pipe(gulp.dest('build/'))
 });

--- a/README.md
+++ b/README.md
@@ -299,6 +299,23 @@ Default: `false`
 
 Enable experimental Decorator support.
 
+#### options.additionalTscParameters
+Type: String
+Default: null
+
+This option is used to pass any parameter to tsc command. Especially it can be used to pass parameters not yet suported by gulp-tsc. 
+
+Example:
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.tsx'])
+    .pipe(typescript({
+      additionalTscParameters: '--jsx react'
+    }))
+    .pipe(gulp.dest('build/'))
+});
+```
+
 ## Error handling
 
 If gulp-tsc fails to compile files, it emits `error` event with `gutil.PluginError` as the manner of gulp plugins.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -44,7 +44,7 @@ function Compiler(sourceFiles, options) {
         safe:              false,
         emitDecoratorMetadata: false,
         experimentalDecorators: false,
-        additionalTscParameters: null
+        additionalTscParameters: []
     }, options);
     this.options.sourceMap = this.options.sourceMap || this.options.sourcemap;
     delete this.options.sourcemap;
@@ -81,7 +81,7 @@ Compiler.prototype.buildTscArguments = function (version) {
   if (this.options.noLib)             args.push('--noLib');
   if (this.options.emitDecoratorMetadata)    args.push('--emitDecoratorMetadata');
   if (this.options.experimentalDecorators)    args.push('--experimentalDecorators');
-  if (this.options.additionalTscParameters)   args.push(this.options.additionalTscParameters)
+  if (this.options.additionalTscParameters)   this.options.additionalTscParameters.forEach(function (param) { args.push(param); });
 
   if (this.tempDestination) {
     args.push('--outDir', this.tempDestination);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -43,7 +43,8 @@ function Compiler(sourceFiles, options) {
         pathFilter:        null,
         safe:              false,
         emitDecoratorMetadata: false,
-        experimentalDecorators: false
+        experimentalDecorators: false,
+        additionalTscParameters: null
     }, options);
     this.options.sourceMap = this.options.sourceMap || this.options.sourcemap;
     delete this.options.sourcemap;
@@ -80,6 +81,7 @@ Compiler.prototype.buildTscArguments = function (version) {
   if (this.options.noLib)             args.push('--noLib');
   if (this.options.emitDecoratorMetadata)    args.push('--emitDecoratorMetadata');
   if (this.options.experimentalDecorators)    args.push('--experimentalDecorators');
+  if (this.options.additionalTscParameters)   args.push(this.options.additionalTscParameters)
 
   if (this.tempDestination) {
     args.push('--outDir', this.tempDestination);


### PR DESCRIPTION
This change will allow to pass any parameter to tsc command. Especially it can be useful to pass not yet supported parameters to future tsc versions.
