### PR TITLE
Removing unnecessary space that breaks compilation

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -143,11 +143,11 @@ Compiler.prototype.buildTscArguments = function (version) {
     }
 
     if (this.options.moduleResolution && versionCompare(version, "1.6") >= 0) {
-        args.push('--moduleResolution ', this.options.moduleResolution);
+        args.push('--moduleResolution', this.options.moduleResolution);
     }
 
     if (this.options.project && versionCompare(version, "1.6") >= 0) {
-        args.push('--project ', this.options.project);
+        args.push('--project', this.options.project);
     }
   if (this.options.additionalTscParameters)   this.options.additionalTscParameters.forEach(function (param) { args.push(param); });
 


### PR DESCRIPTION
The unnecessary space makes tsc complain about the value of moduleResolution not being a recognized value because it takes the empty string as the value

Example of the error produced by tsc when the moduleResolution options is used because of the space

```
[16:05:35] Compiling TypeScript files using tsc version 1.8.10
[16:05:35] [tsc] > error TS5023: Unknown compiler option 'moduleresolution '.
[16:05:35] Failed to compile TypeScript: Error: tsc command has exited with code:1
```
